### PR TITLE
fix: fix header white margin in mobile

### DIFF
--- a/src/components/shared/layout/LayoutHeaderMobile.tsx
+++ b/src/components/shared/layout/LayoutHeaderMobile.tsx
@@ -87,12 +87,18 @@ const { Container, Content, WalletContainer, Logo, MenuContainer, SettingIcon, M
     display: grid;
     grid-template-columns: auto 1fr;
     gap: ${({ theme }) => theme.size[24]};
+    @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+      gap: 2px;
+    }
   `,
   WalletContainer: styled.div`
     display: flex;
     align-items: center;
     gap: ${({ theme }) => theme.size[8]};
     justify-content: flex-end;
+    @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+      gap: 2px;
+    }
   `,
   Logo: styled(Link)`
     width: 40px;


### PR DESCRIPTION
![mobile](https://github.com/staketogether/st-v1-interface/assets/71525496/5cbf6144-5c6a-4835-a8ed-439b554bdb8e)


fix white margin in responsive layout header