### PR TITLE
Feat/assets mobile adjust

### DIFF
--- a/src/components/asset/AssetCard.tsx
+++ b/src/components/asset/AssetCard.tsx
@@ -54,7 +54,7 @@ const { CardContainer, ImageContainer, PriceContainer, Soon, NewTag } = {
       color: ${({ theme }) => theme.colorV2.blue[1]};
       font-size: ${({ theme }) => theme.font.size[22]};
       font-weight: 500;
-      border-radius: ${({ theme }) => theme.size[8]};
+      border-radius: ${({ theme }) => theme.size[4]};
       padding: ${({ theme }) => theme.size[4]} ${({ theme }) => theme.size[8]};
       &.price {
         display: flex;
@@ -70,16 +70,16 @@ const { CardContainer, ImageContainer, PriceContainer, Soon, NewTag } = {
         align-self: end;
         font-size: ${({ theme }) => theme.font.size[16]};
         font-weight: 600;
-        color: ${({ theme }) => theme.color.green[500]};
-        border: 1px solid ${({ theme }) => theme.color.green[500]};
+        color: ${({ theme }) => theme.color.green[400]};
+        border: 1px solid ${({ theme }) => theme.color.green[400]};
       }
 
       &.price-down {
         align-self: end;
         font-weight: 600;
         font-size: ${({ theme }) => theme.font.size[16]};
-        color: ${({ theme }) => theme.color.red[500]};
-        border: 1px solid ${({ theme }) => theme.color.red[500]};
+        color: ${({ theme }) => theme.color.red[600]};
+        border: 1px solid ${({ theme }) => theme.color.red[600]};
       }
     }
   `,

--- a/src/components/asset/AssetControl.tsx
+++ b/src/components/asset/AssetControl.tsx
@@ -94,7 +94,7 @@ const { Container, Products, Title, ContainerButton } = {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: ${({ theme }) => theme.size[24]};
+    gap: ${({ theme }) => theme.size[12]};
 
     @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
       grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));


### PR DESCRIPTION
![Captura de ecrã 2024-06-03 184720](https://github.com/staketogether/st-v1-interface/assets/71525496/971f70c9-f396-4e1e-aafd-35bc4394ff8d)


OBS, the "Mobile Menu " change is found in the pull request: STAKING mobile adjust, requiring merging to take effect here, as it is a component. The "Menu Header mobile " was found in the "pull request update header mobile", requiring the same change. This pull request only focuses on asset list layout adjustments, colors and spacing like in figma
